### PR TITLE
support upcoming Listen 3.x version

### DIFF
--- a/lib/spring/watcher/listen.rb
+++ b/lib/spring/watcher/listen.rb
@@ -4,10 +4,15 @@ require "spring/watcher/abstract"
 require "listen"
 require "listen/version"
 
-# fork() doesn't preserve threads, so a clean
-# Celluloid shutdown isn't possible, but we can
-# reduce the 10 second timeout
-Celluloid.shutdown_timeout = 2
+if defined?(Celluloid)
+  # fork() doesn't preserve threads, so a clean
+  # Celluloid shutdown isn't possible, but we can
+  # reduce the 10 second timeout
+
+  # There's a patch for Celluloid to avoid this (search for 'fork' in Celluloid
+  # issues)
+  Celluloid.shutdown_timeout = 2
+end
 
 module Spring
   module Watcher
@@ -31,9 +36,10 @@ module Spring
       end
 
       def subjects_changed
-        if @listener && @listener.directories.sort != base_directories.sort
-          restart
-        end
+        return unless @listener
+        return unless @listener.respond_to?(:directories)
+        return unless @listener.directories.sort != base_directories.sort
+        restart
       end
 
       def watching?(file)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,7 +4,9 @@ require "bundler/setup"
 require "spring/test"
 require "minitest/autorun"
 
-require "celluloid/test"
-Celluloid.logger.level = Logger::WARN
+if defined?(Celluloid)
+  require "celluloid/test"
+  Celluloid.logger.level = Logger::WARN
+end
 
 Spring::Test.root = File.expand_path('..', __FILE__)

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -7,9 +7,9 @@ class ListenWatcherTest < Spring::Test::WatcherTest
     Spring::Watcher::Listen
   end
 
-  setup {
-    Celluloid.boot
-  }
+  setup do
+    Celluloid.boot if defined?(Celluloid)
+  end
 
   teardown { Listen.stop }
 


### PR DESCRIPTION
- avoids using Celluloid, since Listen 3.x will work without it
- ideally, Listen 1.x could still be supported also (with Listen::Compat)
