### PR TITLE
relax version dependency to support Listen 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: ruby
+rvm:
+  - 2.2.2

--- a/spring-watcher-listen.gemspec
+++ b/spring-watcher-listen.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activesupport"
 
   spec.add_dependency "spring", "~> 1.2"
-  spec.add_dependency "listen", "~> 2.7"
+  spec.add_dependency "listen", ">= 2.7", '< 4.0'
 end


### PR DESCRIPTION
Allow users to decide whether to use Listen 2.x or 3.x with Spring
