### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,16 @@
 language: ruby
+cache: bundler
+dist: trusty
+sudo: false
+before_script:
+  - travis_retry gem install rails --version '~> 5.1.0'
+
 rvm:
-  - 2.3.1
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,21 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
-Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.test_files = FileList["test/*_test.rb"]
-  t.verbose = true
+namespace :test do
+  Rake::TestTask.new(:unit) do |t|
+    t.libs << "test"
+    t.test_files = FileList["test/unit_test.rb"]
+    t.verbose = true
+  end
+
+  Rake::TestTask.new(:acceptance) do |t|
+    t.libs << "test"
+    t.test_files = FileList["test/acceptance_test.rb"]
+    t.verbose = true
+  end
 end
+
+desc 'Run tests'
+task test: ['test:unit', 'test:acceptance']
 
 task default: :test


### PR DESCRIPTION
I updated Rubies to latest version.
I also added `ruby-head` as `allow_failures`.

I think this is useful.
Because we can support the next version Ruby as faster.
  
We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.
https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

Is it possible to merge?

Thanks.