### PR TITLE
Fix "warning: instance variable @listener not initialized"

### DIFF
--- a/lib/spring/watcher/listen.rb
+++ b/lib/spring/watcher/listen.rb
@@ -22,21 +22,21 @@ module Spring
       attr_reader :listener
 
       def start
-        unless @listener
+        unless defined?(@listener)
           @listener = ::Listen.to(*base_directories, latency: latency, &method(:changed))
           @listener.start
         end
       end
 
       def stop
-        if @listener
+        if defined?(@listener)
           @listener.stop
           @listener = nil
         end
       end
 
       def subjects_changed
-        return unless @listener
+        return unless defined?(@listener)
         return unless @listener.respond_to?(:directories)
         return unless @listener.directories.sort != base_directories.sort
         restart


### PR DESCRIPTION
Currently, the following error is shows.

```
spring-watcher-listen/lib/spring/watcher/listen.rb:39: warning: instance variable @listener not initialized
spring-watcher-listen/lib/spring/watcher/listen.rb:32: warning: instance variable @listener not initialized
spring-watcher-listen/lib/spring/watcher/listen.rb:25: warning: instance variable @listener not initialized
```
