### PR TITLE
Really delete the directories.

### DIFF
--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -27,8 +27,8 @@ class ListenWatcherTest < Spring::Test::WatcherTest
       dirs = [dir, other_dir_1, other_dir_2].sort.map { |path| Pathname.new(path) }
       assert_equal dirs, watcher.base_directories.sort
     ensure
-      FileUtils.rmdir other_dir_1
-      FileUtils.rmdir other_dir_2
+      FileUtils.rm_rf other_dir_1
+      FileUtils.rm_rf other_dir_2
     end
   end
 
@@ -49,8 +49,8 @@ class ListenWatcherTest < Spring::Test::WatcherTest
       dirs = [dir, other_dir_1, other_dir_2].sort.map { |path| Pathname.new(path) }
       assert_equal dirs, watcher.base_directories.sort
     ensure
-      FileUtils.rmdir other_dir_1
-      FileUtils.rmdir other_dir_2
+      FileUtils.rm_rf other_dir_1
+      FileUtils.rm_rf other_dir_2
     end
   end
 end


### PR DESCRIPTION
The FileUtils.rmdir deletes just empty directories and secretly fails to
do so in Ruby 2.4. Ruby 2.5 fixes the behavior [1] and FileUtiles.rmdir
fails with error such as:

~~~
Errno::ENOTEMPTY: Directory not empty @ dir_s_rmdir - /tmp/d20180114-8362-1iuw12n_other
~~~

[1] https://bugs.ruby-lang.org/issues/13889