### PR TITLE
Support spring 3.0

### DIFF
--- a/spring-watcher-listen.gemspec
+++ b/spring-watcher-listen.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "activesupport"
 
-  spec.add_dependency "spring", ">= 1.2", "< 3.0"
+  spec.add_dependency "spring", ">= 1.2", "< 4.0"
   spec.add_dependency "listen", ">= 2.7", '< 4.0'
 end


### PR DESCRIPTION
This loosens the version query for spring to support [the newly released 3.0](https://github.com/rails/spring/blob/master/CHANGELOG.md#300). [The changes](https://github.com/rails/spring/compare/v2.1.1...v3.0.0) appear to be mostly around dropping support for older Rails versions, so there shouldn't be any changes needed in this library.

Closes #25 