### PR TITLE
Disable with `DISABLE_SPRING_WATCHER_LISTEN` env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ On larger projects this means spring will be more responsive, more accurate and 
 Listen 2.7 and higher and 3.0 are supported.
 If you rely on Listen 1 you can use v1.0.0 of this gem.
 
+## Environment variables
+
+* `DISABLE_SPRING_WATCHER_LISTEN` - If set, this disables the loading of this gem. This can be useful for projects where
+    some configurations do not support inotify (e.g. Docker on M1 Macs).
+
 ## Installation
 
 Stop Spring if it's already running:

--- a/lib/spring/watcher/listen.rb
+++ b/lib/spring/watcher/listen.rb
@@ -1,3 +1,5 @@
+return if ENV['DISABLE_SPRING_WATCHER_LISTEN']
+
 require "spring/watcher"
 require "spring/watcher/abstract"
 


### PR DESCRIPTION
We have a project where some Engineers are running configurations that do not support `inotify`, which causes an error when this gem is loaded. We still want these Engineers to be able to use Spring in polling mode. We tried setting `require: false` in the `Gemfile` but [Spring loads the gem anyway](https://github.com/rails/spring/blob/a318a1837524ea6e39a7073af94e75131fcc95d1/lib/spring/commands.rb#L35-L46).

This change introduces a new env var `DISABLE_SPRING_WATCHER_LISTEN` which, along the lines of `DISABLE_SPRING`, disables the functionality in this gem.

There are probably a few ways to solve this problem but I wanted to submit this for your consideration. Feedback welcome!