### PR TITLE
support spring 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,11 @@ cache: bundler
 dist: trusty
 sudo: false
 before_script:
-  - travis_retry gem install rails --version '~> 5.1.0'
+  - travis_retry gem install rails --version '~> 6.1.0'
 
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.7.3
+  - 3.0.3
   - ruby-head
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache: bundler
-dist: trusty
+dist: bionic
 sudo: false
 before_script:
   - travis_retry gem install rails --version '~> 6.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Specify your gem's dependencies in spring-watcher-listen.gemspec
 gemspec
 
-gem "spring", github: "rails/spring"
+gem "spring", github: "rails/spring", branch: :main

--- a/lib/spring/watcher/listen.rb
+++ b/lib/spring/watcher/listen.rb
@@ -43,7 +43,7 @@ module Spring
       end
 
       def watching?(file)
-        files.include?(file) || file.start_with?(*directories)
+        files.include?(file) || file.start_with?(*directories.keys)
       end
 
       def changed(modified, added, removed)
@@ -56,8 +56,8 @@ module Spring
 
       def base_directories
         ([root] +
-          files.reject       { |f| f.start_with? "#{root}/" }.map { |f| File.expand_path("#{f}/..") } +
-          directories.reject { |d| d.start_with? "#{root}/" }
+          files.keys.reject       { |f| f.start_with? "#{root}/" }.map { |f| File.expand_path("#{f}/..") } +
+          directories.keys.reject { |d| d.start_with? "#{root}/" }
         ).uniq.map { |path| Pathname.new(path) }
       end
     end

--- a/spring-watcher-listen.gemspec
+++ b/spring-watcher-listen.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "activesupport"
 
-  spec.add_dependency "spring", ">= 1.2", "< 4.0"
+  spec.add_dependency "spring", ">= 4", "< 5"
   spec.add_dependency "listen", ">= 2.7", '< 4.0'
 end

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -6,6 +6,9 @@ class ListenWatcherTest < Spring::Test::WatcherTest
     Spring::Watcher::Listen
   end
 
+  # this test, as currently written, can only run against polling implementations
+  undef :test_add_directory_with_dangling_symlink
+
   setup do
     Celluloid.boot if defined?(Celluloid)
   end


### PR DESCRIPTION
This runs ok on my rails 6.1 apps with spring 4. Main cause of incompatibility was 
https://github.com/rails/spring/commit/7f4ddf9f280012e2af7a43f8a96b310a4d26235a#diff-8079047024eafaf078a5ec33c6e989295d077b3306c92c168a4cc043c9f780b2

There is one remaining failing test - this comes from https://github.com/rails/spring/blob/main/test/support/watcher_test.rb#L192

As far as I can tell this has probably always failed: this expects a watcher to have a check_stale method which spring-watcher-listen has never had. This feels like a spec of the polling implementation rather than a spec of the high level functionality - check_stale in poller.rb is the main 'walk all the files and check their mtime', which is a concept that just doesn't existing in spring-watcher-listen.