### PR TITLE
Pass ignore options to Listen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', 'head' ]
-        rails: [ '6.0', '6.1', '7.0', 'edge' ]
-        exclude:
-          - ruby: '3.1'
-            rails: '6.0'
-          - ruby: '3.1'
-            rails: '6.1'
+        ruby: [ '3.2', '3.3', '3.4', 'head' ]
+        rails: [ '7.1', '7.2', '8.0', 'edge' ]
 
     env:
       RAILS_VERSION: ${{ matrix.rails }}

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,11 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in spring-watcher-listen.gemspec
 gemspec
 
+gem "drb"
+gem "logger"
+gem "mutex_m"
+gem "timeout"
+
 if ENV["RAILS_VERSION"] == "edge"
   gem "activesupport", github: "rails/rails", branch: "main"
 elsif ENV["RAILS_VERSION"]

--- a/README.md
+++ b/README.md
@@ -32,3 +32,20 @@ Add this line to your application's Gemfile:
 And then execute:
 
     $ bundle
+
+## Ignoring files and directories
+
+Listen ignores some files and directories by default, including `.git`, `log`, `tmp`, and `vendor`
+(see the `Listen::Silencer` [source](https://github.com/guard/listen/blob/master/lib/listen/silencer.rb) for the full list).
+To improve performance and/or prevent unwanted restarts, you can adjust these patterns in your `config/spring.rb`:
+
+```ruby
+Spring.watcher.tap do |watcher|
+  watcher.ignore  [/^node_modules/] # Add more pattern(s) to be ignored
+  watcher.ignore! [/^\.git/]        # Or overwrite all default ignored patterns
+  watcher.only    [/\.rb$/]         # Only listen for specific file patterns (not applied to directories)
+end
+```
+
+These options are passed to Listen and reapplied when the watcher restarts.
+For more information, see the [Listen gem README](https://github.com/guard/listen?tab=readme-ov-file#ignore--ignore).

--- a/lib/spring/watcher/listen.rb
+++ b/lib/spring/watcher/listen.rb
@@ -31,7 +31,13 @@ module Spring
       def start
         return if @listener
 
-        @listener = ::Listen.to(*base_directories, latency: latency, &method(:changed))
+        options = {
+          latency: latency,
+          ignore:  @ignores,
+          ignore!: @forced_ignores,
+          only:    @onlys
+        }.compact
+        @listener = ::Listen.to(*base_directories, **options, &method(:changed))
         @listener.start
       end
 
@@ -63,6 +69,22 @@ module Spring
             mark_stale
           end
         end
+      end
+
+      def ignore(regexps)
+        regexps = Array(regexps)
+        (@ignores ||= []).concat(regexps)
+        @listener&.ignore(regexps)
+      end
+
+      def ignore!(regexps)
+        @forced_ignores = Array(regexps)
+        @listener&.ignore!(@forced_ignores)
+      end
+
+      def only(regexps)
+        @onlys = regexps || false
+        @listener&.only(@onlys)
       end
 
       def mark_stale

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
 require "bundler/setup"
+require "logger"
 require File.dirname(Gem::Specification.find_by_name("spring").loaded_from) + "/test/support/test"
 require "minitest/autorun"
 

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -73,4 +73,23 @@ class ListenWatcherTest < Spring::Test::WatcherTest
     Timeout.timeout(1) { sleep 0.1 while watcher.running? }
     assert_equal 1, on_stale_count
   end
+
+  test "passes ignore options to listener" do
+    watcher.add @dir
+    watcher.ignore(/\.not_ignored.tmp$/) # .tmp file ignored by default
+    watcher.ignore!(/ignored\.txt$/)     # not be ignored by default, overrides previous
+    watcher.only(/\.tmp$/)                  # also ignore non .tmp files
+    watcher.start
+
+    touch "#{@dir}/ignored.txt"
+    assert_not_stale
+
+    watcher.restart
+
+    touch "#{@dir}/still_ignored.txt"
+    assert_not_stale
+
+    touch "#{@dir}/not_ignored.tmp"
+    assert_stale
+  end
 end


### PR DESCRIPTION
When watching the Rails root directory, Listen tracks the state of everything inside unless matched by its silencer patterns. Large directories like `node_modules` can impact performance even when they aren't explicitly watched by Spring.

This adds `ignore`, `ignore!`, and `only` methods to configure Listen's silencer.

Fixes #15

---

CI seems to be broken on main right now. I was able to get the unit tests passing but am not sure what's happening with the acceptance tests yet.